### PR TITLE
Use the latest framework code + fix race condition

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,6 @@ all units is possible to configure via the relevant config options.
 
 # Deploy
 
-Note: The charm currently depends on this to-be-merged PR https://github.com/canonical/operator/pull/109
-for working with network spaces.
-
 ```bash
 juju deploy --resource nats=<path-to-nats-snap-file> <nats-charm-dir>
 ```


### PR DESCRIPTION
The nats service supplied with the snap was attempted to be started
(with retries) by snapd before a config was rendered for it. Then the
charm tried to start it by itself which sometimes resulted in a failure.