### PR TITLE
Expose an auth_token to clients via app rdata

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -156,7 +156,7 @@ class NatsCharm(CharmBase):
             self.NATS_SERVER_CONFIG_PATH.write_text(rendered_content)
             if self.state.is_started:
                 subprocess.check_call(['systemctl', 'restart', self.NATS_SERVICE])
-        self.client.expose_nats()
+        self.client.expose_nats(auth_token=self.state.auth_token)
 
     def get_auth_token(self, length=None):
         '''Generate a random auth token.'''

--- a/src/interfaces.py
+++ b/src/interfaces.py
@@ -71,9 +71,9 @@ class NatsClient(Object):
     def set_tls_ca(self, tls_ca):
         self._tls_ca = tls_ca
 
-    def expose_nats(self):
-        rel = self.model.get_relation(self._relation_name)
-        if rel is not None:
+    def expose_nats(self, auth_token=None):
+        relations = self.model.relations[self._relation_name]
+        for rel in relations:
             if self._tls_ca is not None:
                 url = f'tls://{self.listen_address}:{self._client_port}'
             else:
@@ -81,3 +81,5 @@ class NatsClient(Object):
             rel.data[self.model.unit]['url'] = url
             if self.model.unit.is_leader() and self._tls_ca is not None:
                 rel.data[self.model.app]['ca_cert'] = self._tls_ca
+                if auth_token is not None:
+                    rel.data[self.model.app]['auth_token'] = auth_token


### PR DESCRIPTION
Exposes an authentication token over multiple relations via application relation data.

RBAC and multi-user capabilities will be exposed later.