### PR TITLE
templates: enable monitor endpoint on localhost

### DIFF
--- a/templates/nats.cfg.j2
+++ b/templates/nats.cfg.j2
@@ -1,4 +1,7 @@
 listen: {{client_listen_address}}:{{client_port}}
+# By default we listen on localhost only to allow a subordinate telegraf
+# to consume metrics and forward them elsewhere
+http: localhost:8222
 authorization: {
   token: "{{auth_token}}"
 }


### PR DESCRIPTION
In order to consume metrics from NATS a subordinate telegraf can be
deployed alongside the NATS charm and configured to consume metrics from
it and forward for example to prometheus.